### PR TITLE
Added nats/lib to load path for bin/nats-* scripts

### DIFF
--- a/bin/nats-pub
+++ b/bin/nats-pub
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+$:.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
 require 'optparse'
 require 'rubygems'
 require 'nats/client'

--- a/bin/nats-queue
+++ b/bin/nats-queue
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+$:.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
 require 'optparse'
 require 'rubygems'
 require 'nats/client'

--- a/bin/nats-server
+++ b/bin/nats-server
@@ -2,4 +2,5 @@
 # NATS command line interface script.
 # Run <tt>nats-server -h</tt> to get more usage.
 
+$:.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
 require 'nats/server'

--- a/bin/nats-sub
+++ b/bin/nats-sub
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+$:.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
 require 'optparse'
 require 'rubygems'
 require 'nats/client'


### PR DESCRIPTION
Now bin/nats-\* scripts can be executed on the command line like below:
    `~/nats$ ruby bin/nats-server`
