### PR TITLE
Add rake to the Gemfile's test group.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'daemons', '>= 1.1.0'
 gem 'json_pure', :require => 'json'
 
 group :test do
+  gem 'rake'
   gem 'rspec'
   gem 'nats', :path => '.'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     eventmachine (0.12.10)
     eventmachine (0.12.10-java)
     json_pure (1.5.1)
+    rake (0.9.2)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -32,4 +33,5 @@ DEPENDENCIES
   eventmachine (>= 0.12.10)
   json_pure
   nats!
+  rake
   rspec


### PR DESCRIPTION
rake is not part of the bundle, so running `bundle exe rake` fails.
