### PR TITLE
More tests for NATS client configuration

### DIFF
--- a/spec/client_config_spec.rb
+++ b/spec/client_config_spec.rb
@@ -94,7 +94,7 @@ describe "client configuration" do
 
   it 'should respect the reconnect parameters' do
     expect do
-      NATS.start(:connect => true, :max_reconnect_attempts => 2, :reconnect_time_wait => 2) do
+      NATS.start(:connect => true, :max_reconnect_attempts => 1, :reconnect_time_wait => 1) do
         NATS.stop
       end
     end.to_not raise_error
@@ -102,7 +102,7 @@ describe "client configuration" do
     # Stop the server, make sure it can't connect and see that the time to fail make sense
     start_at = nil
     expect do
-      NATS.start(:reconnect => true, :max_reconnect_attempts => 2, :reconnect_time_wait => 1) do
+      NATS.start(:reconnect => true, :max_reconnect_attempts => 1, :reconnect_time_wait => 1) do
         @s.kill_server
         start_at = Time.now
         NATS.publish('test', 'test'){ NATS.stop }
@@ -111,8 +111,8 @@ describe "client configuration" do
     time_diff = Time.now - start_at
 
     # Check if the reconnect took more than the expected 4 secs...
-    time_diff.should >= 3
-    time_diff.should < 5
+    time_diff.should >= 2
+    time_diff.should < 4
   end
 
 end


### PR DESCRIPTION
This two commits add two more things to the client configuration test:

1) Check the URI parameter (I had to use 127.0.0.1 instead of localhost, so that it still connects correctly, but the option is different)

2) Check the handling of reconnect tries

Hopefully those will improve the testing coverage and options.
