### PR TITLE
Fix typo in Getting Started for bash event designator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This gem currently works on the following Ruby platforms:
     [sudo] rake geminstall
 
     nats-sub foo &
-    nats-pub foo "Hello World!'
+    nats-pub foo 'Hello World!'
 
 ## Usage
 


### PR DESCRIPTION
Use single quotes instead of double quotes because bash evaluates '!' as event designator.
