### PR TITLE
By default ssl is not explicit option

### DIFF
--- a/spec/server_config_spec.rb
+++ b/spec/server_config_spec.rb
@@ -18,7 +18,6 @@ describe "server configuration" do
     opts.should have_key :max_control_line
     opts.should have_key :max_payload
     opts.should have_key :max_pending
-    opts.should have_key :ssl
 
     opts[:port].should == NATSD::DEFAULT_PORT
     opts[:addr].should == NATSD::DEFAULT_HOST


### PR DESCRIPTION
Remove test in server_config_spec.rb in default options with no command line arguments
