### PR TITLE
added nats-request for executables

### DIFF
--- a/bin/nats-request
+++ b/bin/nats-request
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'rubygems'
+require 'nats/client'
+
+['TERM', 'INT'].each { |s| trap(s) {  puts; exit! } }
+
+def usage
+  puts "Usage: nats-request <subject> <msg> [-s server] [-t] [-n responses]"; exit
+end
+
+args = ARGV.dup
+opts_parser = OptionParser.new do |opts|
+  opts.on('-s SERVER') { |server| $nats_server = server }
+  opts.on('-t') { $show_time = true }
+  opts.on('-n RESPONSES') { |responses| $responses = Integer(responses) if Integer(responses) > 0 }
+end
+args = opts_parser.parse!(args)
+
+subject, msg = args
+usage unless subject
+msg ||= 'Hello World'
+
+def time_prefix
+  "[#{Time.now}] " if $show_time
+end
+
+def header
+  $i=0 unless $i
+  "#{time_prefix}[\##{$i+=1}]"
+end
+
+NATS.on_error { |err| puts "Server Error: #{err}"; exit! }
+
+NATS.start(:uri => $nats_server, :autostart => true) do
+  NATS.request(subject, msg) { |(msg, reply)|
+    puts "#{header} Replied with : '#{msg}'"
+    exit! if $responses && ($responses-=1) < 1
+  }
+end

--- a/nats.gemspec
+++ b/nats.gemspec
@@ -23,7 +23,7 @@ spec = Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
   s.bindir = 'bin'
-  s.executables = [NATSD::APP_NAME, 'nats-pub', 'nats-sub', 'nats-queue', 'nats-top']
+  s.executables = [NATSD::APP_NAME, 'nats-pub', 'nats-sub', 'nats-queue', 'nats-top', 'nats-request']
 
   s.files = %w[
     COPYING
@@ -36,6 +36,7 @@ spec = Gem::Specification.new do |s|
     bin/nats-pub
     bin/nats-queue
     bin/nats-top
+	bin/nats-request
     lib/nats/client.rb
     lib/nats/ext/bytesize.rb
     lib/nats/ext/em.rb


### PR DESCRIPTION
An example where it could be useful is when want to discover all vcap components connected to the NATS:

<pre>
$ nats-request  vcap.component.discover 
[#1] Replied with : '{"type":"DEA","index":null,"uuid":"0092a091d1937275840ac955a81f6926","host":"192.168.1.124:42757","credentials":["xxxx","yyy"],"start":"2012-01-30 04:41:33 +0200","uptime":"0d:10h:23m:58s"}'
[#2] Replied with : '{"type":"RaaS-Node","index":0,"uuid":"0-4e2a965d10d5ad7190a52bf68f01b4a1","host":"192.168.1.124:49683","credentials":["xxx","yyy"],"start":"2012-01-30 04:41:37 +0200","uptime":"0d:10h:23m:54s"}'
...
</pre>
