### PR TITLE
monitoring info

### DIFF
--- a/lib/nats/server/server.rb
+++ b/lib/nats/server/server.rb
@@ -53,6 +53,14 @@ module NATSD #:nodoc: all
           :max_payload => @max_payload
         }
 
+        if @options[:http_port]
+          @info[:http_port] = @options[:http_port]
+          if @options[:http_user]
+            @info[:http_user] = @options[:http_user]
+            @info[:http_password] = @options[:http_password]
+          end
+        end
+
         # Check for daemon flag
         if @options[:daemonize]
           require 'rubygems'


### PR DESCRIPTION
It would be nice to have access to the healtz, varz and connz monitoring endpoint without looking into the config file.
Maybe the INFO json message sent by the server would be a good place to put the monitoring info, so I am making this pull request with this change to the server side.

This is an actual INFO message with the chanage:

INFO {"server_id": "1309a7a66bc7f84e05e9de3782","host": "localhost","port": 4242,"version": "0.4.22.beta.8","auth_required": false,"ssl_required": false,"max_payload": 512000,"http_port": 9222,"http_user": "derek","http_password": "foo"}
