### PR TITLE
Fix typo to print out value of '$1' when matched UNKNOWN protcol in client.

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -517,7 +517,7 @@ module NATS
           process_info($1)
         when UNKNOWN
           @buf = $'
-          err_cb.call(NATS::ServerError.new("Unknown protocol: $1"))
+          err_cb.call(NATS::ServerError.new("Unknown protocol: #{$1}"))
         else
           # If we are here we do not have a complete line yet that we understand.
           return


### PR DESCRIPTION
I'd see the value of $1 when data received matched "UNKNOWN" in the exception.

I guess this is just typo. isn't it?
