### PR TITLE
non-zero exit when server can't read config

### DIFF
--- a/lib/nats/server/options.rb
+++ b/lib/nats/server/options.rb
@@ -1,4 +1,3 @@
-
 require 'optparse'
 require 'yaml'
 
@@ -107,7 +106,7 @@ module NATSD
 
       rescue => e
         log "Could not read configuration file:  #{e}"
-        exit
+        exit 1
       end
 
       def setup_logs


### PR DESCRIPTION
When `nats-server` is passed a path to a missing config file, it exits 0. That makes it rather... challenging... for an initscript to know it failed ;)
