### PR TITLE
Fix to show the contents of $1 when matched UNKNOWN on client

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -517,7 +517,7 @@ module NATS
           process_info($1)
         when UNKNOWN
           @buf = $'
-          err_cb.call(NATS::ServerError.new("Unknown protocol: $1"))
+          err_cb.call(NATS::ServerError.new("Unknown protocol: #{$1}"))
         else
           # If we are here we do not have a complete line yet that we understand.
           return

--- a/spec/error_on_client_spec.rb
+++ b/spec/error_on_client_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'error on client' do
+
+  context 'NATS::ServerError' do
+
+    it 'should show the contents of $1 when matched UNKNOWN' do
+       EchoServer.start{
+         EM.reactor_running?.should be_true
+         NATS.on_error{|e|
+           # We use a CONNECT request to match Unknown Protcol
+           #e.to_s.should match(/\AUnknown Protocol: CONNECT\s+.*/i)
+           e.to_s.should match(/\AUnknown Protocol: CONNECT.+/i)
+
+           NATS.stop;
+           EchoServer.stop
+         }
+
+         # Send CONNECT request to the server.
+         NATS.start(:uri => EchoServer::ECHO_SERVER)
+       }
+
+       NATS.connected?.should be_false
+       EM.reactor_running?.should be_false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,3 +73,27 @@ class NatsServerControl
     end
   end
 end
+
+module EchoServer
+
+  HOST = "localhost".freeze
+  PORT = "9999".freeze
+  ECHO_SERVER = "http://#{HOST}:#{PORT}".freeze
+
+  def receive_data(data)
+    send_data(data)
+  end
+
+  class << self
+    def start(&blk)
+      EM.run {
+        EventMachine::start_server(HOST, PORT, self)
+        blk.call
+      }
+    end
+
+    def stop
+      EM.stop_event_loop
+    end
+  end
+end


### PR DESCRIPTION
This is a re-opened pull request.

I put the test together as you asked in the previous pull request.

With this patch, it will be able to show the data sent from the sever when UNKNOWN protocol is processed and a NATS::ServerError occurs.
