### PR TITLE
client would be disconnected when reconnecting to un authorized server

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -579,6 +579,7 @@ module NATS
     @reconnecting = true
     @reconnect_attempts = 0
     @connected = false
+    @pending, @pending_size = nil, 0
     @reconnect_timer = EM.add_periodic_timer(wait) { attempt_reconnect }
   end
 
@@ -615,6 +616,7 @@ module NATS
 
   def send_command(command) #:nodoc:
     EM.next_tick { flush_pending } if (connected? && @pending.nil?)
+    return false if (reconnecting? && (command !~ /^CONNECT /))
     (@pending ||= []) << command
     @pending_size += command.bytesize
     flush_pending if (connected? && @pending_size > MAX_PENDING_SIZE)


### PR DESCRIPTION
When a correct client reconnects to un authorized server, the server disconnects the client in some cases.
The server gives AUTH_REQUIRED error because the client sends messages, for example, created by add_periodic_timer method before the server recieves CONNECT message.

Modified client as follows.
・clear pending messages at unbind.
・don't add a message except CONNECT message to pending messages while reconnecting.

Added a test.
・publish a message without error even if reconnected to un authorized server.
