### PR TITLE
Publishing user now passed to client callback events.

### DIFF
--- a/examples/auth_sub.rb
+++ b/examples/auth_sub.rb
@@ -16,5 +16,5 @@ NATS.on_error { |err| puts "Server Error: #{err}"; exit! }
 
 NATS.start(:uri => uri) do
   puts "Listening on [#{subject}]"
-  NATS.subscribe(subject) { |msg, _, sub| puts "Received on [#{sub}] : '#{msg}'" }
+  NATS.subscribe(subject) { |msg, _, sub, user| puts "Received on [#{sub}] from [#{user}] : '#{msg}'" }
 end

--- a/spec/protocol_spec.rb
+++ b/spec/protocol_spec.rb
@@ -248,49 +248,65 @@ describe 'NATS Protocol' do
     end
 
     it 'should process messages' do
+      str = "MSG@user foo 2 11\r\nHello World\r\n"
+      NATS::MSG =~ str
+      $1.should == 'user'
+      $2.should == 'foo'
+      $3.should == '2'
+      $5.should == nil
+      $6.to_i.should == 11
+      $'.should == "Hello World\r\n"
+    end
+
+    it 'should process messages without user' do
       str = "MSG foo 2 11\r\nHello World\r\n"
       NATS::MSG =~ str
-      $1.should == 'foo'
-      $2.should == '2'
-      $4.should == nil
-      $5.to_i.should == 11
+      $1.should == nil
+      $2.should == 'foo'
+      $3.should == '2'
+      $5.should == nil
+      $6.to_i.should == 11
       $'.should == "Hello World\r\n"
     end
 
     it 'should process messages with a reply' do
-      str = "MSG foo  2 reply_to_me 11\r\nHello World\r\n"
+      str = "MSG@user foo  2 reply_to_me 11\r\nHello World\r\n"
       NATS::MSG =~ str
-      $1.should == 'foo'
-      $2.should == '2'
-      $4.should == 'reply_to_me'
-      $5.to_i.should == 11
+      $1.should == 'user'
+      $2.should == 'foo'
+      $3.should == '2'
+      $5.should == 'reply_to_me'
+      $6.to_i.should == 11
       $'.should == "Hello World\r\n"
     end
 
     it 'should process messages with extra spaces' do
-      str = "MSG    foo  2     reply_to_me  11\r\nHello World\r\n"
+      str = "MSG@user    foo  2     reply_to_me  11\r\nHello World\r\n"
       NATS::MSG =~ str
-      $1.should == 'foo'
-      $2.should == '2'
-      $4.should == 'reply_to_me'
-      $5.to_i.should == 11
+      $1.should == 'user'
+      $2.should == 'foo'
+      $3.should == '2'
+      $5.should == 'reply_to_me'
+      $6.to_i.should == 11
       $'.should == "Hello World\r\n"
     end
 
     it 'should process multiple messages in a single read properly' do
-      str = "MSG foo 2 11\r\nHello World\r\nMSG foo  2 reply_to_me 2\r\nok\r\n"
+      str = "MSG@user foo 2 11\r\nHello World\r\nMSG foo  2 reply_to_me 2\r\nok\r\n"
       NATS::MSG =~ str
-      $1.should == 'foo'
-      $2.should == '2'
-      $4.should == nil
-      $5.to_i.should == 11
+      $1.should == 'user'
+      $2.should == 'foo'
+      $3.should == '2'
+      $5.should == nil
+      $6.to_i.should == 11
       str = $'
-      str = str.slice($5.to_i + NATSD::CR_LF_SIZE, str.bytesize)
+      str = str.slice($6.to_i + NATSD::CR_LF_SIZE, str.bytesize)
       NATS::MSG =~ str
-      $1.should == 'foo'
-      $2.should == '2'
-      $4.should == 'reply_to_me'
-      $5.to_i.should == 2
+      $1.should == nil
+      $2.should == 'foo'
+      $3.should == '2'
+      $5.should == 'reply_to_me'
+      $6.to_i.should == 2
       $'.should == "ok\r\n"
     end
 


### PR DESCRIPTION
We are looking to build an authorization layer on top of NATs, so as a starting point I have enhanced the server so that it will pass the user publishing a message on to the subscriber.

Since the NATS server is authenticating incoming connections, I thought it is safest to let it control the labelling of the messages.

To to do this I have extended the MSG message to take an optional @username immediately after the MSG. This means that current unauthenticated messages will not change.

Please let me know if this is the kind of thing you would like to pull in, or if you would like any changes to the implementation.

.. Gavin
