### PR TITLE
Correct ssl option handling

### DIFF
--- a/lib/nats/server/options.rb
+++ b/lib/nats/server/options.rb
@@ -173,7 +173,7 @@ module NATSD
 
         @auth_required = (not @options[:user].nil?)
 
-        @ssl_required = (not @options[:ssl].nil?)
+        @ssl_required = @options[:ssl]
 
         # Pings
         @options[:ping_interval] ||= DEFAULT_PING_INTERVAL

--- a/spec/server_config_spec.rb
+++ b/spec/server_config_spec.rb
@@ -85,4 +85,42 @@ describe "server configuration" do
     NATSD::Server.log_time.should be_true
   end
 
+  describe "NATSD::Server.finalize_options" do
+    before do
+      NATSD::Server.process_options
+    end
+
+    context "ssl setting is nothing" do
+      before do
+        NATSD::Server.options[:ssl] = nil
+      end
+
+      it "shoud properly set @ssl_required to nil" do
+        NATSD::Server.finalize_options
+        NATSD::Server.ssl_required.should be_false
+      end
+    end
+
+    context "ssl setting is false" do
+      before do
+        NATSD::Server.options[:ssl] = false
+      end
+
+      it "should properly set @ssl_required to false" do
+        NATSD::Server.finalize_options
+        NATSD::Server.ssl_required.should be_false
+      end
+    end
+
+    context "ssl setting is true" do
+      before do
+        NATSD::Server.options[:ssl] = true
+      end
+
+      it "should properly set @ssl_required to true" do
+        NATSD::Server.finalize_options
+        NATSD::Server.ssl_required.should be_true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Please look at this line. https://github.com/derekcollison/nats/blob/master/lib/nats/server/options.rb#L176

When the content of options[:ssl] is "false", ssl_required should be "false", too.

But In the current version, ssl_required is "true" even if  the content of options[:ssl] is "false". The results of my test is below:

<pre>
|  config file   |  ssl_required  |
|      none      |     false      |
|     false      |      true      |
|      true      |      true      |
</pre>


I think this should be as below:

<pre>
|  config file   |  ssl_required  |
|      none      |     false      |
|     false      |     false      |
|      true      |      true      |
</pre>


I fixed it that ssl_required become "false" when options[:ssl] is "false".
