### PR TITLE
Use SecureRandom for inbox name

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'securerandom'
 
 ep = File.expand_path(File.dirname(__FILE__))
 
@@ -207,9 +208,7 @@ module NATS
     # Returns a subject that can be used for "directed" communications.
     # @return [String]
     def create_inbox
-      v = [rand(0x0010000),rand(0x0010000),rand(0x0010000),
-           rand(0x0010000),rand(0x0010000),rand(0x1000000)]
-      "_INBOX.%04x%04x%04x%04x%04x%06x" % v
+      "_INBOX.#{SecureRandom.hex(13)}"
     end
 
     # Flushes all messages and subscriptions in the default connection

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -318,4 +318,21 @@ describe 'client specification' do
     NATS.start(opts) { NATS.stop }
   end
 
+  describe '#create_inbox' do
+    it 'create the expected format' do
+      expect(NATS.create_inbox).to match(/_INBOX\.[a-f0-9]{12}/)
+    end
+
+    context 'when Kernel.srand is regularly reset to the same value' do
+      it 'should generate a unique inbox name' do
+        Kernel.srand 5555
+        first_inbox_name = NATS.create_inbox
+
+        Kernel.srand 5555
+        second_inbox_name = NATS.create_inbox
+
+        expect(second_inbox_name).to_not eq(first_inbox_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Use SecureRandom for inbox name to isolate the client from manipulation of Kernel.srand

This addresses an issue with inbox name collision when running under
RSpec which sets Kernel.srand to specific value before every example
