### PR TITLE
restrict thin dependency to < 1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 gem 'eventmachine', '= 0.12.10'
 gem 'daemons', '>= 1.1.5'
 gem 'json_pure', '>= 1.7.3', :require => 'json'
-gem 'thin', '>= 1.4.1'
+gem 'thin', '>= 1.4.1', '< 1.6'
 
 group :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       daemons (>= 1.1.5)
       eventmachine (= 0.12.10)
       json_pure (>= 1.7.3)
-      thin (>= 1.4.1)
+      thin (>= 1.4.1, < 1.6)
 
 GEM
   remote: http://rubygems.org/
@@ -41,4 +41,4 @@ DEPENDENCIES
   nats!
   rake
   rspec (>= 2.11.0)
-  thin (>= 1.4.1)
+  thin (>= 1.4.1, < 1.6)

--- a/nats.gemspec
+++ b/nats.gemspec
@@ -19,7 +19,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency('eventmachine', '= 0.12.10')
   s.add_dependency('json_pure', '>= 1.7.3')
   s.add_dependency('daemons', '>= 1.1.5')
-  s.add_dependency('thin', '>= 1.4.1')
+  s.add_dependency('thin', '>= 1.4.1', '< 1.6')
 
   s.require_paths = ['lib']
   s.bindir = 'bin'


### PR DESCRIPTION
1.6 requires eventmachine 1.x, which fails to resolve

As we decided here https://github.com/derekcollison/nats/pull/59 instead of bumping eventmachine lock down thin.
