### PR TITLE
bug fix for cluster.routes option

### DIFF
--- a/lib/nats/server/options.rb
+++ b/lib/nats/server/options.rb
@@ -119,7 +119,7 @@ module NATSD
             @route_auth_required = true
           end
           if routes = cluster['routes']
-            @options[:cluster_routes] = routes if @options[:cluster_routes].nil?
+            @options[:cluster_routes] = routes.split(' ') if @options[:cluster_routes].nil?
           end
         end
 


### PR DESCRIPTION
YAML option variable "cluster.routes" is extracted as String with space.
[Changed] convert "cluster.routes" String as Array type.
