### PR TITLE
Modify EM version dependency

### DIFF
--- a/nats.gemspec
+++ b/nats.gemspec
@@ -16,7 +16,7 @@ spec = Gem::Specification.new do |s|
   s.authors = ['Derek Collison']
   s.email = ['derek.collison@gmail.com']
 
-  s.add_dependency('eventmachine', '= 0.12.10')
+  s.add_dependency('eventmachine', '>= 0.12.10')
   s.add_dependency('json_pure', '>= 1.7.3')
   s.add_dependency('daemons', '>= 1.1.5')
   s.add_dependency('thin', '>= 1.4.1', '< 1.6')


### PR DESCRIPTION
Hi Derek,

'rake geminstall' and 'gem install nats' don't work due to a version inconsistency between thin & nats, so I've modified EM's dependency slightly.
