### PR TITLE
Fix send_command to trigger flush_pending if @pending exists

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -731,12 +731,17 @@ module NATS
   end
 
   def send_command(command, priority = false) #:nodoc:
-    EM.next_tick { flush_pending } if (connected? && @pending.nil?)
     @pending ||= []
     @pending << command unless priority
     @pending.unshift(command) if priority
     @pending_size += command.bytesize
-    flush_pending if (connected? && @pending_size > MAX_PENDING_SIZE)
+    if connected?
+      if @pending_size > MAX_PENDING_SIZE
+        flush_pending
+      else
+        EM.next_tick { flush_pending }
+      end
+    end
     if (@options[:fast_producer_error] && pending_data_size > FAST_PRODUCER_THRESHOLD)
       err_cb.call(NATS::ClientError.new("Fast Producer: #{pending_data_size} bytes outstanding"))
     end


### PR DESCRIPTION
In original code, flush_pending is triggered(EM.next_tick) when @pending is nil,
and flush_pending does nothing if @pending is nil.
In my environment, published message does not deliver to server until periodic
ping triggered.
