### PR TITLE
update eventmachine to 1.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem 'eventmachine', '= 0.12.10'
+gem 'eventmachine', '~> 1.0.0'
 gem 'daemons', '>= 1.1.5'
 gem 'json_pure', '>= 1.7.3', :require => 'json'
 gem 'thin', '>= 1.4.1', '< 1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     nats (0.4.28)
       daemons (>= 1.1.5)
-      eventmachine (= 0.12.10)
+      eventmachine (~> 1.0.0)
       json_pure (>= 1.7.3)
       thin (>= 1.4.1, < 1.6)
 
@@ -12,7 +12,7 @@ GEM
   specs:
     daemons (1.1.9)
     diff-lcs (1.2.5)
-    eventmachine (0.12.10)
+    eventmachine (1.0.3)
     json_pure (1.8.1)
     rack (1.5.2)
     rake (10.1.1)
@@ -34,7 +34,7 @@ PLATFORMS
 
 DEPENDENCIES
   daemons (>= 1.1.5)
-  eventmachine (= 0.12.10)
+  eventmachine (~> 1.0.0)
   json_pure (>= 1.7.3)
   nats!
   rake

--- a/nats.gemspec
+++ b/nats.gemspec
@@ -16,7 +16,7 @@ spec = Gem::Specification.new do |s|
   s.authors = ['Derek Collison']
   s.email = ['derek.collison@gmail.com']
 
-  s.add_dependency('eventmachine', '= 0.12.10')
+  s.add_dependency('eventmachine', '~> 1.0.0')
   s.add_dependency('json_pure', '>= 1.7.3')
   s.add_dependency('daemons', '>= 1.1.5')
   s.add_dependency('thin', '>= 1.4.1', '< 1.6')


### PR DESCRIPTION
Since thin changed its depended eventmachine version to 1.0.0 or above,
NATS doesn't work with latest thin.
Moreover, eventmachine 0.12.10 has issue on Ubuntu 12.10 or above.
https://github.com/eventmachine/eventmachine/issues/345
