### PR TITLE
Add method to get snapshot of in/out msgs/bytes stats

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nats (0.11.0)
+    nats (0.11.2)
       eventmachine (~> 1.2, >= 1.2)
 
 GEM

--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -777,6 +777,16 @@ module NATS
     get_outbound_data_size + @pending_size
   end
 
+  # Return snapshot of current traffic flow stats in the client.
+  def stats
+    {
+      in_msgs: @msgs_received,
+      out_msgs: @msgs_sent,
+      in_bytes: @bytes_received,
+      out_bytes: @bytes_sent
+    }.freeze
+  end
+
   def user_err_cb? # :nodoc:
     err_cb_overridden || NATS.err_cb_overridden
   end

--- a/lib/nats/version.rb
+++ b/lib/nats/version.rb
@@ -14,7 +14,7 @@
 
 module NATS
   # NOTE: These are all announced to the server on CONNECT
-  VERSION = "0.11.0".freeze
+  VERSION = "0.11.2".freeze
   LANG    = RUBY_ENGINE
   PROTOCOL_VERSION = 1
 end


### PR DESCRIPTION
Adds a simple helper to get inbound/outbound stats from the client similar to the Go client.

```ruby
      NATS.start("demo.nats.io") do |nats|
        # Snapshot the stats from either of the callbacks
        nats.subscribe("foo") {
          # {:in_msgs=>1, :out_msgs=>1, :in_bytes=>5, :out_bytes=>5}
          p nats.stats
        }
        nats.publish("foo", "world")
      end
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>